### PR TITLE
Parallelize collection execution

### DIFF
--- a/engine/execution/messages.go
+++ b/engine/execution/messages.go
@@ -43,6 +43,10 @@ func (cr *ComputationResult) AddTransactionResult(inp *flow.TransactionResult) {
 	cr.TransactionResults = append(cr.TransactionResults, *inp)
 }
 
+func (cr *ComputationResult) AddIndexedTransactionResult(inp *flow.TransactionResult, index int) {
+	cr.TransactionResults[index] = *inp
+}
+
 func (cr *ComputationResult) AddComputationUsed(inp uint64) {
 	cr.ComputationUsed += inp
 }


### PR DESCRIPTION
Parallelize collection execution. Unit tests still passing. Execution results are ordered the same as if they had been executed serially. This pull request does not guarantee that the resulting ledger state is correct. The execution does not account for conflicting transactions yet. q